### PR TITLE
Fix missing openssl dependency 

### DIFF
--- a/lib/omnitrade_api/client.rb
+++ b/lib/omnitrade_api/client.rb
@@ -1,5 +1,6 @@
 require 'json'
 require 'net/http'
+require 'openssl'
 require_relative 'client/version'
 
 module OmniTradeAPI


### PR DESCRIPTION
Fix this bug:
`lib/omnitrade_api/auth.rb:21:in `sign': uninitialized constant OmniTradeAPI::Auth::OpenSSL (NameError)
Did you mean?  OpenStruct`